### PR TITLE
Add Python version with notebook and tests

### DIFF
--- a/Heli3Dof.ipynb
+++ b/Heli3Dof.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Heli3Dof Demo\n",
+    "Basic usage example of the Python model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from heli3dof.kinematics import f_kine_heli3dof\n",
+    "from heli3dof.visualization import plot_heli3dof\n",
+    "from heli3dof.simulation import simulate\n",
+    "\n",
+    "# initial state and parameters\n",
+    "state0 = np.zeros(6)\n",
+    "t = np.linspace(0, 3, 300)\n",
+    "\n",
+    "def controller(t, x):\n",
+    "    phi_d = np.pi/4\n",
+    "    Kp = 5.0\n",
+    "    Kd = 2.5\n",
+    "    e = phi_d - x[2]\n",
+    "    edot = -x[3]\n",
+    "    u = np.array([Kp*e + Kd*edot, Kp*e + Kd*edot])\n",
+    "    return u\n",
+    "\n",
+    "traj, inputs = simulate(state0, controller, t)\n",
+    "\n",
+    "# plot final configuration\n",
+    "pos = f_kine_heli3dof(traj[-1,0], traj[-1,2], traj[-1,4], 0.1, 1.0, 1.0)\n",
+    "plot_heli3dof(pos)\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Heli3Dof
-3DoF Hellicopter modeling, simulation, and control
+
+A simple 3‑degree‑of‑freedom helicopter model. The original implementation was
+in MATLAB; this repository now provides a basic Python version with
+visualisation utilities and a Jupyter notebook ready for Google Colab.
+
+## Requirements
+
+```
+pip install -r requirements.txt
+```
+
+## Running the tests
+
+```
+pytest
+```
+
+## Using the notebook
+
+Open `Heli3Dof.ipynb` in Jupyter or upload it to [Google Colab](https://colab.research.google.com/). It demonstrates how to compute the kinematics,
+simulate a simple PD controller and visualise the result.

--- a/heli3dof/__init__.py
+++ b/heli3dof/__init__.py
@@ -1,0 +1,13 @@
+from .kinematics import f_kine_heli3dof
+from .visualization import plot_heli3dof
+from .dynamics import heli3dof_dynamics
+from .simulation import simulate
+from .inertia import inertia_yaw_heli3dof
+
+__all__ = [
+    "f_kine_heli3dof",
+    "plot_heli3dof",
+    "heli3dof_dynamics",
+    "simulate",
+    "inertia_yaw_heli3dof",
+]

--- a/heli3dof/dynamics.py
+++ b/heli3dof/dynamics.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+
+def heli3dof_dynamics(t: float, x: np.ndarray, u: np.ndarray,
+                      params: dict | None = None) -> np.ndarray:
+    """Dynamics of the 3-DOF helicopter.
+
+    Parameters
+    ----------
+    t : float
+        Current time (unused but included for compatibility).
+    x : ndarray, shape (6,)
+        State vector [theta, theta_dot, phi, phi_dot, psi, psi_dot].
+    u : ndarray, shape (2,)
+        Control inputs [front_motor_force, back_motor_force].
+    params : dict, optional
+        Dictionary with model parameters. If None, default parameters are
+        used.
+
+    Returns
+    -------
+    ndarray, shape (6,)
+        Time derivative of the state.
+    """
+    if params is None:
+        params = {
+            "Jx": 1.0,
+            "Jy": 1.0,
+            "Jz": 1.0,
+            "R": 0.25,
+            "L": 0.5,
+            "mcp": 2.0,
+            "mm": 2.5,
+            "g": 9.8,
+        }
+
+    Jx = params["Jx"]
+    Jy = params["Jy"]
+    Jz = params["Jz"]
+    R = params["R"]
+    L = params["L"]
+    mcp = params["mcp"]
+    mm = params["mm"]
+    g = params["g"]
+
+    dx = np.zeros_like(x)
+    dx[0] = x[1]
+    dx[1] = (u[0] - u[1]) / (2 * Jx * R)
+    dx[2] = x[3]
+    dx[3] = (u[0] + u[1]) / (Jy * L) * np.cos(x[0]) - (mm - mcp) * g / Jy * np.cos(x[2])
+    dx[4] = x[5]
+    dx[5] = (u[0] + u[1]) / (Jz * L) * np.sin(x[0]) * np.cos(x[2])
+
+    return dx

--- a/heli3dof/inertia.py
+++ b/heli3dof/inertia.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+def inertia_yaw_heli3dof(pos: dict, m_motor: float, m_green: float, m_red: float) -> float:
+    """Compute the yaw inertia of the helicopter."""
+
+    def rod_inertia(p1: np.ndarray, p2: np.ndarray, m: float) -> float:
+        return (m / 3) * (np.dot(p1, p1) + np.dot(p1, p2) + np.dot(p2, p2))
+
+    o = pos["base"][:2]
+    rR = pos["motor_R"][:2] - o
+    rL = pos["motor_L"][:2] - o
+    r_cp = pos["cp"][:2] - o
+    r_cm_A = pos["cm_A"][:2] - o
+
+    Jz = (
+        m_motor * (rR[0] ** 2 + rR[1] ** 2)
+        + m_motor * (rL[0] ** 2 + rL[1] ** 2)
+        + rod_inertia(r_cp, r_cm_A, m_green)
+        + rod_inertia(rL, rR, m_red)
+    )
+    return Jz

--- a/heli3dof/kinematics.py
+++ b/heli3dof/kinematics.py
@@ -1,0 +1,28 @@
+import numpy as np
+from .utils import rot_x, rot_y, rot_z
+
+
+def f_kine_heli3dof(theta: float, alpha: float, psi: float,
+                    L_A: float, L_B: float, L_C: float) -> dict:
+    """Direct kinematics of the 3-DOF helicopter."""
+    Rz = rot_z(psi)
+    Ry = rot_y(alpha)
+    green_vector = Rz @ Ry @ np.array([1.0, 0.0, 0.0])
+
+    pivot_green = np.array([0.0, 0.0, 0.75 * L_C])
+
+    green_start = pivot_green - (L_B / 2) * green_vector
+    green_end = pivot_green + (L_B / 2) * green_vector
+
+    red_axis = np.array([0.0, 1.0, 0.0])
+    Rx = rot_x(theta)
+    arm_vector = Rz @ Ry @ Rx @ red_axis
+
+    pos = {}
+    pos["motor_R"] = green_end + L_A * arm_vector
+    pos["motor_L"] = green_end - L_A * arm_vector
+    pos["cm_A"] = green_end
+    pos["cm_B"] = pivot_green
+    pos["cp"] = green_start
+    pos["base"] = pivot_green
+    return pos

--- a/heli3dof/simulation.py
+++ b/heli3dof/simulation.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import numpy as np
+from .dynamics import heli3dof_dynamics
+
+
+def simulate(initial_state: np.ndarray, controller, t: np.ndarray,
+             params: dict | None = None) -> tuple[np.ndarray, np.ndarray]:
+    """Simulate the helicopter using Euler integration."""
+    x = np.zeros((len(t), len(initial_state)))
+    u = np.zeros((len(t), 2))
+    x[0] = initial_state
+    for i in range(1, len(t)):
+        dt = t[i] - t[i - 1]
+        u[i] = controller(t[i - 1], x[i - 1])
+        dx = heli3dof_dynamics(t[i - 1], x[i - 1], u[i], params)
+        x[i] = x[i - 1] + dx * dt
+    return x, u

--- a/heli3dof/utils.py
+++ b/heli3dof/utils.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+def rot_x(a: float) -> np.ndarray:
+    """Rotation matrix around X-axis."""
+    ca, sa = np.cos(a), np.sin(a)
+    return np.array([[1, 0, 0], [0, ca, -sa], [0, sa, ca]])
+
+
+def rot_y(a: float) -> np.ndarray:
+    """Rotation matrix around Y-axis."""
+    ca, sa = np.cos(a), np.sin(a)
+    return np.array([[ca, 0, sa], [0, 1, 0], [-sa, 0, ca]])
+
+
+def rot_z(a: float) -> np.ndarray:
+    """Rotation matrix around Z-axis."""
+    ca, sa = np.cos(a), np.sin(a)
+    return np.array([[ca, -sa, 0], [sa, ca, 0], [0, 0, 1]])

--- a/heli3dof/visualization.py
+++ b/heli3dof/visualization.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d.art3d import Line3D
+
+
+def plot_heli3dof(pos: dict, ax: plt.Axes | None = None) -> plt.Axes:
+    """Plot the configuration of the 3-DOF helicopter."""
+    if ax is None:
+        fig = plt.figure(figsize=(6, 6))
+        ax = fig.add_subplot(111, projection="3d")
+    else:
+        fig = ax.figure
+
+    ax.cla()
+    ax.set_xlabel("X [m]")
+    ax.set_ylabel("Y [m]")
+    ax.set_zlabel("Z [m]")
+    ax.set_title("Helicopter 3-DOF")
+    ax.grid(True)
+
+    # blue post
+    ax.plot([0, 0], [0, 0], [0, pos["base"][2] / 0.75], "b-", linewidth=4)
+
+    # green beam
+    ax.plot([pos["cp"][0], pos["cm_A"][0]],
+            [pos["cp"][1], pos["cm_A"][1]],
+            [pos["cp"][2], pos["cm_A"][2]],
+            "g-", linewidth=3)
+
+    # red arm
+    ax.plot([pos["motor_L"][0], pos["motor_R"][0]],
+            [pos["motor_L"][1], pos["motor_R"][1]],
+            [pos["motor_L"][2], pos["motor_R"][2]],
+            "r-", linewidth=3)
+
+    # highlight key points
+    ax.scatter(pos["base"][0], pos["base"][2] / 0.75, pos["base"][2] / 0.75, color="b")
+    ax.scatter(pos["cp"][0], pos["cp"][1], pos["cp"][2], color="g")
+    ax.scatter(pos["cm_A"][0], pos["cm_A"][1], pos["cm_A"][2], color="g")
+    ax.scatter(pos["motor_L"][0], pos["motor_L"][1], pos["motor_L"][2], color="r")
+    ax.scatter(pos["motor_R"][0], pos["motor_R"][1], pos["motor_R"][2], color="r")
+
+    ax.set_xlim([-1, 1])
+    ax.set_ylim([-1, 1])
+    ax.set_zlim([0, pos["base"][2] / 0.75])
+
+    plt.draw()
+    return ax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -1,0 +1,15 @@
+import numpy as np
+from heli3dof.dynamics import heli3dof_dynamics
+
+
+def test_dynamics_zero_input():
+    x = np.zeros(6)
+    u = np.zeros(2)
+    dx = heli3dof_dynamics(0.0, x, u)
+    assert dx[0] == 0
+    assert dx[1] == 0
+    assert dx[2] == 0
+    assert dx[4] == 0
+    assert dx[5] == 0
+    # pitch acceleration is due to gravity difference
+    assert np.isclose(dx[3], -(2.5 - 2.0) * 9.8)

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -1,0 +1,14 @@
+import numpy as np
+from heli3dof.kinematics import f_kine_heli3dof
+
+
+def test_zero_angles_positions():
+    L_A = 0.1
+    L_B = 1.0
+    L_C = 1.0
+    pos = f_kine_heli3dof(0.0, 0.0, 0.0, L_A, L_B, L_C)
+    np.testing.assert_allclose(pos["motor_R"], [L_B/2, L_A, 0.75*L_C])
+    np.testing.assert_allclose(pos["motor_L"], [L_B/2, -L_A, 0.75*L_C])
+    np.testing.assert_allclose(pos["cm_A"], [L_B/2, 0.0, 0.75*L_C])
+    np.testing.assert_allclose(pos["cp"], [-L_B/2, 0.0, 0.75*L_C])
+    np.testing.assert_allclose(pos["base"], [0.0, 0.0, 0.75*L_C])


### PR DESCRIPTION
## Summary
- migrate MATLAB code to Python package `heli3dof`
- add kinematics, dynamics, simulation and plotting utilities
- provide a demo Jupyter notebook for Colab
- update README with instructions
- add simple pytest suite for kinematics and dynamics

## Testing
- `pip install -q numpy matplotlib pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685899341a608333ae303340f00029e0