### PR TITLE
Add fuzzy control and EKF helper utilities for notebook workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ pytest
 
 Open `Heli3Dof.ipynb` in Jupyter or upload it to [Google Colab](https://colab.research.google.com/). It demonstrates how to compute the kinematics,
 simulate a simple PD controller and visualise the result.
+
+
+## New utilities for class notebooks
+
+The package now includes two helper modules used in control/estimation classes:
+
+- `heli3dof.control`: compact fuzzy-PD utilities and a pitch/roll controller that maps angle errors into front/back motor forces.
+- `heli3dof.estimation`: generic EKF predict/update helpers with numerical Jacobians for nonlinear models.
+
+These helpers are intentionally lightweight so they can be reused directly in notebooks for experiments and homework.

--- a/heli3dof/__init__.py
+++ b/heli3dof/__init__.py
@@ -3,6 +3,8 @@ from .visualization import plot_heli3dof
 from .dynamics import heli3dof_dynamics
 from .simulation import simulate
 from .inertia import inertia_yaw_heli3dof
+from .control import fuzzy_pd_torque, fuzzy_pitch_roll_controller
+from .estimation import ekf_predict, ekf_update
 
 __all__ = [
     "f_kine_heli3dof",
@@ -10,4 +12,8 @@ __all__ = [
     "heli3dof_dynamics",
     "simulate",
     "inertia_yaw_heli3dof",
+    "fuzzy_pd_torque",
+    "fuzzy_pitch_roll_controller",
+    "ekf_predict",
+    "ekf_update",
 ]

--- a/heli3dof/control.py
+++ b/heli3dof/control.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def _triangular_membership(value: float, center: float, width: float) -> float:
+    """Triangular membership function in [0, 1]."""
+    distance = abs(value - center)
+    if distance >= width:
+        return 0.0
+    return 1.0 - distance / width
+
+
+def fuzzy_pd_torque(error: float, error_rate: float, *,
+                    error_scale: float = 1.0,
+                    rate_scale: float = 1.0,
+                    output_gain: float = 1.0) -> float:
+    """Compute a smooth control action using a compact fuzzy PD rule base.
+
+    The rule base uses 3 linguistic labels for each input:
+    negative, zero and positive.
+    """
+    e = np.clip(error / error_scale, -1.0, 1.0)
+    de = np.clip(error_rate / rate_scale, -1.0, 1.0)
+
+    mu_e = {
+        "N": _triangular_membership(e, -1.0, 1.0),
+        "Z": _triangular_membership(e, 0.0, 1.0),
+        "P": _triangular_membership(e, 1.0, 1.0),
+    }
+    mu_de = {
+        "N": _triangular_membership(de, -1.0, 1.0),
+        "Z": _triangular_membership(de, 0.0, 1.0),
+        "P": _triangular_membership(de, 1.0, 1.0),
+    }
+
+    # consequents in normalized output domain [-1, 1]
+    rule_output = {
+        ("N", "N"): -1.0,
+        ("N", "Z"): -0.7,
+        ("N", "P"): -0.3,
+        ("Z", "N"): -0.4,
+        ("Z", "Z"): 0.0,
+        ("Z", "P"): 0.4,
+        ("P", "N"): 0.3,
+        ("P", "Z"): 0.7,
+        ("P", "P"): 1.0,
+    }
+
+    numerator = 0.0
+    denominator = 0.0
+    for le, me in mu_e.items():
+        for lde, mde in mu_de.items():
+            firing = me * mde
+            numerator += firing * rule_output[(le, lde)]
+            denominator += firing
+
+    if denominator == 0.0:
+        return 0.0
+    return output_gain * (numerator / denominator)
+
+
+def fuzzy_pitch_roll_controller(state: np.ndarray,
+                                references: tuple[float, float],
+                                *,
+                                hover_force: float = 0.0,
+                                max_delta_force: float = 1.5) -> np.ndarray:
+    """Simple fuzzy controller that maps pitch/roll errors to motor forces.
+
+    State order: [theta, theta_dot, phi, phi_dot, psi, psi_dot].
+    """
+    theta_ref, phi_ref = references
+    theta, theta_dot, phi, phi_dot = state[0], state[1], state[2], state[3]
+
+    diff_force = fuzzy_pd_torque(theta_ref - theta, -theta_dot, output_gain=max_delta_force)
+    collective = fuzzy_pd_torque(phi_ref - phi, -phi_dot, output_gain=max_delta_force)
+
+    u_front = hover_force + collective + diff_force
+    u_back = hover_force + collective - diff_force
+    return np.array([u_front, u_back], dtype=float)

--- a/heli3dof/estimation.py
+++ b/heli3dof/estimation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def _finite_difference_jacobian(fun, x: np.ndarray, eps: float = 1e-6) -> np.ndarray:
+    f0 = np.asarray(fun(x), dtype=float)
+    jac = np.zeros((f0.size, x.size), dtype=float)
+    for i in range(x.size):
+        dx = np.zeros_like(x)
+        dx[i] = eps
+        jac[:, i] = (np.asarray(fun(x + dx), dtype=float) - f0) / eps
+    return jac
+
+
+def ekf_predict(x: np.ndarray, p: np.ndarray, u: np.ndarray,
+                process_model, q: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """EKF prediction step for a discrete-time nonlinear system."""
+    f = lambda xx: process_model(xx, u)
+    x_pred = np.asarray(f(x), dtype=float)
+    F = _finite_difference_jacobian(f, x)
+    p_pred = F @ p @ F.T + q
+    return x_pred, p_pred
+
+
+def ekf_update(x_pred: np.ndarray, p_pred: np.ndarray, z: np.ndarray,
+               measurement_model, r: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """EKF correction step using numerical linearization of h(x)."""
+    h = lambda xx: measurement_model(xx)
+    z_pred = np.asarray(h(x_pred), dtype=float)
+    H = _finite_difference_jacobian(h, x_pred)
+
+    y = z - z_pred
+    S = H @ p_pred @ H.T + r
+    K = p_pred @ H.T @ np.linalg.inv(S)
+
+    x_upd = x_pred + K @ y
+    I = np.eye(p_pred.shape[0])
+    p_upd = (I - K @ H) @ p_pred
+    return x_upd, p_upd

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from heli3dof.control import fuzzy_pd_torque, fuzzy_pitch_roll_controller
+
+
+def test_fuzzy_pd_zero_error_returns_zero():
+    assert np.isclose(fuzzy_pd_torque(0.0, 0.0), 0.0)
+
+
+def test_fuzzy_pd_sign():
+    assert fuzzy_pd_torque(0.8, 0.0) > 0.0
+    assert fuzzy_pd_torque(-0.8, 0.0) < 0.0
+
+
+def test_pitch_roll_controller_shape():
+    state = np.zeros(6)
+    u = fuzzy_pitch_roll_controller(state, references=(0.1, -0.1), hover_force=1.0)
+    assert u.shape == (2,)
+    assert np.all(np.isfinite(u))

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from heli3dof.estimation import ekf_predict, ekf_update
+
+
+def test_ekf_linear_system_matches_kalman_step():
+    A = np.array([[1.0, 0.1], [0.0, 1.0]])
+    B = np.array([0.0, 0.1])
+    H = np.array([[1.0, 0.0]])
+
+    def f(x, u):
+        return A @ x + B * u[0]
+
+    def h(x):
+        return H @ x
+
+    x0 = np.array([0.0, 1.0])
+    p0 = np.eye(2) * 0.2
+    q = np.eye(2) * 0.01
+    r = np.array([[0.05]])
+    u = np.array([1.0])
+    z = np.array([0.08])
+
+    xp, pp = ekf_predict(x0, p0, u, f, q)
+    xu, pu = ekf_update(xp, pp, z, h, r)
+
+    assert xp.shape == (2,)
+    assert pp.shape == (2, 2)
+    assert xu.shape == (2,)
+    assert pu.shape == (2, 2)
+    assert np.all(np.linalg.eigvals(pu) >= -1e-10)


### PR DESCRIPTION
### Motivation
- Provide compact, reusable helpers for classroom notebooks to explore fuzzy PD control and EKF-based estimation without adding large dependencies. 
- Make common experiment code (controller primitives and a simple EKF) available directly from the `heli3dof` package so notebooks can import utilities easily.

### Description
- Added `heli3dof.control` implementing a triangular membership function, `fuzzy_pd_torque`, and `fuzzy_pitch_roll_controller` that map angle errors to front/back motor forces. 
- Added `heli3dof.estimation` with `ekf_predict` and `ekf_update` and a `_finite_difference_jacobian` helper for numerical linearization of nonlinear models. 
- Exported the new helpers from `heli3dof.__init__` so they can be imported via `from heli3dof import ...`. 
- Updated `README.md` with a `New utilities for class notebooks` section and added tests `tests/test_control.py` and `tests/test_estimation.py`.

### Testing
- Ran `pytest -q` which executed the full test suite (including the new tests) and completed successfully with `6 passed` (total run time ~1.16s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0decec82548333afbf1dce1628e84c)